### PR TITLE
fix: Remove sequel cruft in ci config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -11,7 +11,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "lib/sequel/pgt_outbox/version.rb"
+          "path": "lib/leopard/version.rb"
         },
         {
           "type": "generic",
@@ -21,7 +21,7 @@
       "exclude-paths": [
         ".release-please-manifest.json",
         ".version.txt",
-        "lib/sequel/pgt_outbox/version.rb",
+        "lib/leopard/version.rb",
         ".rubocop.yml",
         ".overcommit.yml",
         "coverage/coverage.json"

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -22,7 +22,7 @@ minimal DSL for defining endpoints and middleware.
 
 == Requirements
 
-* Ruby >= 3.3.0
+* Ruby >= 3.4.0
 * A running NATS server with the Service API enabled.
 
 == Installation


### PR DESCRIPTION
- **fix: Fixes copypasta cruft from oldgem**
- **docs: Only ruby 3.4+ is going to be supported**
