### PR TITLE
fix: Run in blocking mode, not just non-blocking

### DIFF
--- a/lib/leopard/nats_api_server.rb
+++ b/lib/leopard/nats_api_server.rb
@@ -76,7 +76,7 @@ module Rubyists
         def run(nats_url:, service_opts:, instances: 1, blocking: true)
           logger.info 'Booting NATS API server...'
           # Return the thread pool if non-blocking
-          pool = spawn_instances(nats_url, service_opts, instances) unless blocking
+          pool = spawn_instances(nats_url, service_opts, instances)
           return pool unless blocking
 
           # Otherwise, just sleep the main thread forever

--- a/lib/leopard/nats_api_server.rb
+++ b/lib/leopard/nats_api_server.rb
@@ -76,7 +76,8 @@ module Rubyists
         def run(nats_url:, service_opts:, instances: 1, blocking: true)
           logger.info 'Booting NATS API server...'
           # Return the thread pool if non-blocking
-          return spawn_instances(nats_url, service_opts, instances) unless blocking
+          pool = spawn_instances(nats_url, service_opts, instances) unless blocking
+          return pool unless blocking
 
           # Otherwise, just sleep the main thread forever
           sleep


### PR DESCRIPTION
When returning spawn instances (the pool) in non-blocking mode (for tests)
the behavior to spawn instances in blocking mode was removed. This adds
it back by storing the pool in a variable and returning it in non-blocking
mode.
