### PR TITLE
chore: suppress tests from logging for clearer failures

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,3 +14,7 @@ end
 
 require 'minitest/autorun'
 require_relative '../lib/leopard'
+
+# Suppress tests when running tests
+require 'semantic_logger'
+SemanticLogger.default_level = :fatal


### PR DESCRIPTION
Before:
```
bundle exec rake
Running RuboCop...
Inspecting 15 files
...............

15 files inspected, no offenses detected
Run options: --seed 15607

# Running:

.....................2025-08-01 14:57:49.578008 E [48126:1032 nats_api_server.rb:217]  -- Error processing message:  -- fail
2025-08-01 14:57:49.578387 E [48126:1032 nats_api_server.rb:200]  -- Error processing message:  -- Exception: RuntimeError: boom
<Long nasty stack trace that looks like failing tests>
```

After:
```
bundle exec rake
Running RuboCop...
Inspecting 15 files
...............

15 files inspected, no offenses detected
Run options: --seed 13131

# Running:

.....................

Finished in 0.000816s, 25735.2891 runs/s, 23284.3092 assertions/s.

21 runs, 19 assertions, 0 failures, 0 errors, 0 skips
```